### PR TITLE
Refactoring

### DIFF
--- a/controllers/ccc_drone.go
+++ b/controllers/ccc_drone.go
@@ -11,16 +11,25 @@ import (
 )
 
 func init() {
-	router.Handle("/cccdronetest", Adapt(Wrap(droneCccTest), Files(false), Language(supportedLanguages), Method("POST")))
-	router.Handle("/cccdronerun", Adapt(Wrap(droneCccRun), Files(true), Language(supportedLanguages), Method("POST")))
+	router.Handle("/drones/test", Adapt(Wrap(dispatch("drones", droneCccTest)), Files(false), Language(supportedLanguages), Method("POST")))
+	router.Handle("/drones/run", Adapt(Wrap(dispatch("drones", droneCccRun)), Files(true), Language(supportedLanguages), Method("POST")))
+
+	router.Handle("/drones-2d/test", Adapt(Wrap(dispatch("drones-2d", droneCccTest)), Files(false), Language(supportedLanguages), Method("POST")))
+	router.Handle("/drones-2d/run", Adapt(Wrap(dispatch("drones-2d", droneCccRun)), Files(true), Language(supportedLanguages), Method("POST")))
 }
 
-func droneCccTest(rd requestData, w http.ResponseWriter, r *http.Request) {
-	params, err := cccParams(r, rd)
-	if err != nil {
-		http.Error(w, err.Error(), http.StatusBadRequest)
-		return
+func dispatch(simulatorImage string, handler func(rd requestData, w http.ResponseWriter, params *runner.CCCParams)) func(requestData, http.ResponseWriter, *http.Request) {
+	return func(rd requestData, w http.ResponseWriter, r *http.Request) {
+		params, err := cccParams(r, rd, simulatorImage)
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusBadRequest)
+			return
+		}
+		handler(rd, w, params)
 	}
+}
+
+func droneCccTest(rd requestData, w http.ResponseWriter, params *runner.CCCParams) {
 	if params.Validate {
 		tr, err := runner.CCCValidate(rd.ball, params)
 		if err != nil {
@@ -46,12 +55,7 @@ func droneCccTest(rd requestData, w http.ResponseWriter, r *http.Request) {
 	json.NewEncoder(w).Encode(tr)
 }
 
-func droneCccRun(rd requestData, w http.ResponseWriter, r *http.Request) {
-	params, err := cccParams(r, rd)
-	if err != nil {
-		http.Error(w, err.Error(), http.StatusBadRequest)
-		return
-	}
+func droneCccRun(rd requestData, w http.ResponseWriter, params *runner.CCCParams) {
 	tr, err := runner.CCCRun(rd.ball, params)
 	if err != nil {
 		http.Error(w, "run error: "+err.Error(), http.StatusInternalServerError)
@@ -60,33 +64,31 @@ func droneCccRun(rd requestData, w http.ResponseWriter, r *http.Request) {
 	json.NewEncoder(w).Encode(tr)
 }
 
-func cccParams(r *http.Request, rd requestData) (p runner.CCCParams, err error) {
-	p.Image = "coduno/fingerprint-" + rd.language
-	if r.FormValue("test") == "" {
-		return p, errors.New("invalid test value")
-	}
-	test, err := strconv.Atoi(r.FormValue("test"))
-	if err != nil {
-		return p, err
-	}
-	if test < 1 || test > 4 {
-		return p, errors.New("invalid test value")
-	}
-	p.Test = strconv.Itoa(test)
-	if r.FormValue("level") == "" {
-		return p, errors.New("invalid level value")
-	}
-	level, err := strconv.Atoi(r.FormValue("level"))
-	if err != nil {
-		return p, err
-	}
-	if level < 1 || level > 7 {
-		return p, errors.New("invalid level value")
-	}
-	p.Level = strconv.Itoa(level)
-	if r.FormValue("output_test") == "true" {
-		p.Validate = true
+func cccParams(r *http.Request, rd requestData, simulatorImage string) (*runner.CCCParams, error) {
+	var err error
+
+	// TODO(flowlo): Maybe rename parameter "output_test" to "validate"?
+	p := &runner.CCCParams{
+		Image:          "coduno/fingerprint-" + rd.language,
+		SimulatorImage: simulatorImage,
+		Validate:       r.FormValue("output_test") == "true",
 	}
 
-	return
+	p.Test, err = strconv.Atoi(r.FormValue("test"))
+	if err != nil {
+		return nil, err
+	}
+	if p.Test < 1 || p.Test > 4 {
+		return p, errors.New("invalid test value: expected integer greater than zero and smaller than five")
+	}
+
+	p.Level, err = strconv.Atoi(r.FormValue("level"))
+	if err != nil {
+		return nil, err
+	}
+	if p.Level < 1 || p.Level > 7 {
+		return nil, errors.New("invalid level value: expected integer greater than zero and smaller than eight")
+	}
+
+	return p, nil
 }

--- a/runner/ccc_drone.go
+++ b/runner/ccc_drone.go
@@ -2,103 +2,107 @@ package runner
 
 import (
 	"io"
+	"strconv"
 
 	"github.com/coduno/runtime/model"
 )
 
 type CCCParams struct {
-	Image, Level, Test string
-	Validate           bool
+	Image, SimulatorImage string
+	Level, Test           int
+	Validate              bool
 }
 
-func CCCValidate(ball io.Reader, p CCCParams) (ts model.TestStats, err error) {
+func CCCValidate(ball io.Reader, p *CCCParams) (*model.TestStats, error) {
 	runner := &BestDockerRunner{
 		config: dockerConfig{
-			image:       "flowlo/coduno:simulator",
+			image:       p.SimulatorImage,
 			openStdin:   true,
 			stdinOnce:   true,
 			networkMode: "none",
-			cmd:         []string{p.Level, p.Test, "0"},
-		}}
-	if err = runner.createContainer(); err != nil {
-		return
+			cmd:         []string{strconv.Itoa(p.Level), strconv.Itoa(p.Test), "0"},
+		},
 	}
-	if err = runner.start(); err != nil {
-		return
+
+	if err := runner.createContainer(); err != nil {
+		return nil, err
 	}
-	if err = runner.attach(ball); err != nil {
-		return
+	if err := runner.start(); err != nil {
+		return nil, err
 	}
-	if err = runner.wait(); err != nil {
-		return
+	if err := runner.attach(ball); err != nil {
+		return nil, err
 	}
+	if err := runner.wait(); err != nil {
+		return nil, err
+	}
+
 	str, err := runner.logs()
 	if err != nil {
-		return ts, err
+		return nil, err
 	}
-	if err = runner.inspect(); err != nil {
-		return
+	if err := runner.inspect(); err != nil {
+		return nil, err
 	}
 
 	// NOTE(flowlo): Errors preventing removal are ignored.
 	runner.remove()
 
-	return model.TestStats{
+	return &model.TestStats{
 		Failed: runner.c.State.ExitCode != 0,
 		Stdout: str.Stdout,
 		Stderr: str.Stderr,
 	}, nil
 }
 
-func CCCTest(ball io.Reader, p CCCParams) (ts model.TestStats, err error) {
-	var str model.SimpleTestResult
+func CCCTest(ball io.Reader, p *CCCParams) (*model.TestStats, error) {
 	ccc := &BestDockerRunner{
 		config: dockerConfig{
-			image:           "flowlo/coduno:simulator",
-			cmd:             []string{p.Level, p.Test, "7000"},
+			image:           p.SimulatorImage,
+			cmd:             []string{strconv.Itoa(p.Level), strconv.Itoa(p.Test), "7000"},
 			publishAllPorts: true,
 		}}
 
-	str, err = normalCCCRun(ccc, ball, p.Image)
+	str, err := normalCCCRun(ccc, ball, p.Image)
 	if err != nil {
-		return ts, err
+		return nil, err
 	}
-	if err = ccc.wait(); err != nil {
-		return
+	if err := ccc.wait(); err != nil {
+		return nil, err
 	}
-	if err = ccc.inspect(); err != nil {
-		return
+	if err := ccc.inspect(); err != nil {
+		return nil, err
 	}
 
 	// NOTE(flowlo): Errors preventing removal are ignored.
 	ccc.remove()
 
-	return model.TestStats{
+	return &model.TestStats{
 		Failed: ccc.c.State.ExitCode != 0,
 		Stdout: str.Stdout,
 		Stderr: str.Stderr,
 	}, nil
 }
 
-func CCCRun(ball io.Reader, p CCCParams) (testResult model.SimpleTestResult, err error) {
-	ccc := &BestDockerRunner{
+func CCCRun(ball io.Reader, p *CCCParams) (*model.SimpleTestResult, error) {
+	return normalCCCRun(&BestDockerRunner{
 		config: dockerConfig{
-			image:           "flowlo/coduno:simulator",
-			cmd:             []string{p.Level, "1", "7000"},
+			image:           p.SimulatorImage,
+			cmd:             []string{strconv.Itoa(p.Level), "1", "7000"},
 			publishAllPorts: true,
-		}}
-	return normalCCCRun(ccc, ball, p.Image)
+		},
+	}, ball, p.Image)
 }
 
-func normalCCCRun(ccc *BestDockerRunner, ball io.Reader, image string) (testResult model.SimpleTestResult, err error) {
-	if err = ccc.createContainer(); err != nil {
-		return
+func normalCCCRun(ccc *BestDockerRunner, ball io.Reader, image string) (*model.SimpleTestResult, error) {
+	if err := ccc.createContainer(); err != nil {
+		return nil, err
 	}
-	if err = ccc.start(); err != nil {
-		return
+	if err := ccc.start(); err != nil {
+		return nil, err
 	}
-	if err = ccc.inspect(); err != nil {
-		return
+	if err := ccc.inspect(); err != nil {
+		return nil, err
 	}
 	runner := &BestDockerRunner{
 		config: dockerConfig{
@@ -107,17 +111,17 @@ func normalCCCRun(ccc *BestDockerRunner, ball io.Reader, image string) (testResu
 			stdinOnce: true,
 			links:     []string{ccc.c.ID + ":simulator"},
 		}}
-	if err = runner.createContainer(); err != nil {
-		return
+	if err := runner.createContainer(); err != nil {
+		return nil, err
 	}
-	if err = runner.upload(ball); err != nil {
-		return
+	if err := runner.upload(ball); err != nil {
+		return nil, err
 	}
-	if err = runner.start(); err != nil {
-		return
+	if err := runner.start(); err != nil {
+		return nil, err
 	}
-	if err = runner.wait(); err != nil {
-		return
+	if err := runner.wait(); err != nil {
+		return nil, err
 	}
 
 	// NOTE(flowlo): Errors preventing removal are ignored.

--- a/runner/diff.go
+++ b/runner/diff.go
@@ -10,37 +10,26 @@ import (
 	"github.com/coduno/runtime/model"
 )
 
-func DiffRun(ball, test io.Reader, image string) (ts model.TestStats, err error) {
-	var str model.SimpleTestResult
-	str, err = SimpleRun(ball, image)
+func DiffRun(ball, test io.Reader, image string) (*model.DiffTestResult, error) {
+	str, err := SimpleRun(ball, image)
 	if err != nil {
-		return
+		return nil, err
 	}
-	tr := model.DiffTestResult{
-		SimpleTestResult: str,
-	}
-
-	ts, err = processDiffResults(&tr, test)
-	return
+	return processDiffResults(&model.DiffTestResult{SimpleTestResult: *str}, test)
 }
 
-func processDiffResults(tr *model.DiffTestResult, want io.Reader) (ts model.TestStats, err error) {
+func processDiffResults(tr *model.DiffTestResult, want io.Reader) (*model.DiffTestResult, error) {
 	have := strings.NewReader(tr.Stdout)
 	diffLines, ok, err := compare(want, have)
 	if err != nil {
-		return
+		return nil, err
 	}
 	tr.DiffLines = diffLines
 	tr.Failed = !ok
 
-	ts = model.TestStats{
-		Stdout: tr.Stdout,
-		Stderr: tr.Stderr,
-		Failed: !ok,
-	}
+	return tr, nil
 
 	// _, err = tr.PutWithParent(ctx, sub.Key)
-	return
 }
 
 func compare(want, have io.Reader) ([]int, bool, error) {

--- a/runner/runner.go
+++ b/runner/runner.go
@@ -184,10 +184,10 @@ func (r *BestDockerRunner) wait() (err error) {
 	return nil
 }
 
-func (r *BestDockerRunner) logs() (str model.SimpleTestResult, err error) {
+func (r *BestDockerRunner) logs() (*model.SimpleTestResult, error) {
 	stdout := new(bytes.Buffer)
 	stderr := new(bytes.Buffer)
-	err = dc.Logs(docker.LogsOptions{
+	err := dc.Logs(docker.LogsOptions{
 		Container:    r.c.ID,
 		OutputStream: stdout,
 		ErrorStream:  stderr,
@@ -195,11 +195,10 @@ func (r *BestDockerRunner) logs() (str model.SimpleTestResult, err error) {
 		Stderr:       true,
 	})
 	if err != nil {
-		err = errors.New("runner.logs: " + err.Error())
-		return
+		return nil, errors.New("runner.logs: " + err.Error())
 	}
 
-	return model.SimpleTestResult{
+	return &model.SimpleTestResult{
 		Stdout: stdout.String(),
 		Stderr: stderr.String(),
 		Start:  r.info.start,

--- a/runner/simple.go
+++ b/runner/simple.go
@@ -6,22 +6,22 @@ import (
 	"github.com/coduno/runtime/model"
 )
 
-func SimpleRun(ball io.Reader, image string) (testResult model.SimpleTestResult, err error) {
+func SimpleRun(ball io.Reader, image string) (*model.SimpleTestResult, error) {
 	runner := &BestDockerRunner{
 		config: dockerConfig{
 			image: image,
 		}}
-	if err = runner.createContainer(); err != nil {
-		return
+	if err := runner.createContainer(); err != nil {
+		return nil, err
 	}
-	if err = runner.upload(ball); err != nil {
-		return
+	if err := runner.upload(ball); err != nil {
+		return nil, err
 	}
-	if err = runner.start(); err != nil {
-		return
+	if err := runner.start(); err != nil {
+		return nil, err
 	}
-	if err = runner.wait(); err != nil {
-		return
+	if err := runner.wait(); err != nil {
+		return nil, err
 	}
 	return runner.logs()
 }


### PR DESCRIPTION
- Use struct pointers in returns.
- Avoid named return values where not necessary.
- Generalize handlers a bit more.
